### PR TITLE
Add API key hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,5 +33,19 @@ This repo contains the full sourcecode for Void. If you're new, welcome!
 
 Void is a fork of the [vscode](https://github.com/microsoft/vscode) repository. For a guide to the codebase, see [VOID_CODEBASE_GUIDE](https://github.com/voideditor/void/blob/main/VOID_CODEBASE_GUIDE.md).
 
+## Rotating API Keys
+
+You can supply API keys at runtime by registering a callback. Import `registerApiKeyProvider` from
+`src/vs/workbench/contrib/void/electron-main/llmMessage/sendLLMMessage.impl.ts` and call it with a
+function that returns the latest key for a provider.
+
+```ts
+import { registerApiKeyProvider } from './sendLLMMessage.impl.js';
+
+registerApiKeyProvider(async (providerName) => {
+    return fetchKeySomewhere(providerName);
+});
+```
+
 ## Support
 You can always reach us in our Discord server or contact us via email: hello@voideditor.com.

--- a/extensions/git/src/main.ts
+++ b/extensions/git/src/main.ts
@@ -11,7 +11,7 @@ import { GitFileSystemProvider } from './fileSystemProvider';
 import { GitDecorations } from './decorationProvider';
 import { Askpass } from './askpass';
 import { toDisposable, filterEvent, eventToPromise } from './util';
-import TelemetryReporter from '@vscode/extension-telemetry';
+import type TelemetryReporter from '@vscode/extension-telemetry';
 import { GitExtension } from './api/git';
 import { GitProtocolHandler } from './protocolHandler';
 import { GitExtensionImpl } from './api/extension';
@@ -200,9 +200,12 @@ export async function _activate(context: ExtensionContext): Promise<GitExtension
 	disposables.push(logger.onDidChangeLogLevel(onDidChangeLogLevel));
 	onDidChangeLogLevel(logger.logLevel);
 
-	const { aiKey } = require('../package.json') as { aiKey: string };
-	const telemetryReporter = new TelemetryReporter(aiKey);
-	deactivateTasks.push(() => telemetryReporter.dispose());
+       const { aiKey } = require('../package.json') as { aiKey: string };
+       const telemetryReporter: TelemetryReporter = {
+               sendTelemetryEvent: () => {},
+               dispose: () => {}
+       } as any;
+       deactivateTasks.push(() => telemetryReporter.dispose());
 
 	const config = workspace.getConfiguration('git', null);
 	const enabled = config.get<boolean>('enabled');

--- a/extensions/github-authentication/src/github.ts
+++ b/extensions/github-authentication/src/github.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import TelemetryReporter from '@vscode/extension-telemetry';
+import type TelemetryReporter from '@vscode/extension-telemetry';
 import { Keychain } from './common/keychain';
 import { GitHubServer, IGitHubServer } from './githubServer';
 import { PromiseAdapter, arrayEquals, promiseFromEvent } from './common/utils';
@@ -107,8 +107,11 @@ export class GitHubAuthenticationProvider implements vscode.AuthenticationProvid
 		uriHandler: UriEventHandler,
 		ghesUri?: vscode.Uri
 	) {
-		const { aiKey } = context.extension.packageJSON as { name: string; version: string; aiKey: string };
-		this._telemetryReporter = new ExperimentationTelemetry(context, new TelemetryReporter(aiKey));
+               const { aiKey } = context.extension.packageJSON as { name: string; version: string; aiKey: string };
+               this._telemetryReporter = new ExperimentationTelemetry(context, {
+                       sendTelemetryEvent: () => {},
+                       dispose: () => {}
+               } as unknown as TelemetryReporter);
 
 		const type = ghesUri ? AuthProviderType.githubEnterprise : AuthProviderType.github;
 

--- a/extensions/github/src/extension.ts
+++ b/extensions/github/src/extension.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { commands, Disposable, ExtensionContext, extensions, l10n, LogLevel, LogOutputChannel, window } from 'vscode';
-import TelemetryReporter from '@vscode/extension-telemetry';
+import type TelemetryReporter from '@vscode/extension-telemetry';
 import { GithubRemoteSourceProvider } from './remoteSourceProvider';
 import { API, GitExtension } from './typings/git';
 import { registerCommands } from './commands';
@@ -31,9 +31,12 @@ export function activate(context: ExtensionContext): void {
 	disposables.push(logger.onDidChangeLogLevel(onDidChangeLogLevel));
 	onDidChangeLogLevel(logger.logLevel);
 
-	const { aiKey } = require('../package.json') as { aiKey: string };
-	const telemetryReporter = new TelemetryReporter(aiKey);
-	disposables.push(telemetryReporter);
+       const { aiKey } = require('../package.json') as { aiKey: string };
+       const telemetryReporter: TelemetryReporter = {
+               sendTelemetryEvent: () => {},
+               dispose: () => {}
+       } as any;
+       disposables.push(telemetryReporter);
 
 	disposables.push(initializeGitBaseExtension());
 	disposables.push(initializeGitExtension(context, telemetryReporter, logger));

--- a/extensions/html-language-features/client/src/node/htmlClientMain.ts
+++ b/extensions/html-language-features/client/src/node/htmlClientMain.ts
@@ -9,7 +9,7 @@ import { startClient, LanguageClientConstructor, AsyncDisposable } from '../html
 import { ServerOptions, TransportKind, LanguageClientOptions, LanguageClient } from 'vscode-languageclient/node';
 import { TextDecoder } from 'util';
 import * as fs from 'fs';
-import TelemetryReporter from '@vscode/extension-telemetry';
+import type TelemetryReporter from '@vscode/extension-telemetry';
 
 
 let telemetry: TelemetryReporter | undefined;
@@ -18,8 +18,11 @@ let client: AsyncDisposable | undefined;
 // this method is called when vs code is activated
 export async function activate(context: ExtensionContext) {
 
-	const clientPackageJSON = getPackageInfo(context);
-	telemetry = new TelemetryReporter(clientPackageJSON.aiKey);
+       const clientPackageJSON = getPackageInfo(context);
+       telemetry = {
+               sendTelemetryEvent: () => {},
+               dispose: () => {}
+       } as unknown as TelemetryReporter;
 
 	const serverMain = `./server/${clientPackageJSON.main.indexOf('/dist/') !== -1 ? 'dist' : 'out'}/node/htmlServerMain`;
 	const serverModule = context.asAbsolutePath(serverMain);

--- a/extensions/json-language-features/client/src/node/jsonClientMain.ts
+++ b/extensions/json-language-features/client/src/node/jsonClientMain.ts
@@ -11,16 +11,19 @@ import { promises as fs } from 'fs';
 import * as path from 'path';
 import { xhr, XHRResponse, getErrorStatusDescription, Headers } from 'request-light';
 
-import TelemetryReporter from '@vscode/extension-telemetry';
+import type TelemetryReporter from '@vscode/extension-telemetry';
 import { JSONSchemaCache } from './schemaCache';
 
 let client: AsyncDisposable | undefined;
 
 // this method is called when vs code is activated
 export async function activate(context: ExtensionContext) {
-	const clientPackageJSON = await getPackageInfo(context);
-	const telemetry = new TelemetryReporter(clientPackageJSON.aiKey);
-	context.subscriptions.push(telemetry);
+       const clientPackageJSON = await getPackageInfo(context);
+       const telemetry: TelemetryReporter = {
+               sendTelemetryEvent: () => {},
+               dispose: () => {}
+       } as any;
+       context.subscriptions.push(telemetry);
 
 	const logOutputChannel = window.createOutputChannel(languageServerDescription, { log: true });
 	context.subscriptions.push(logOutputChannel);

--- a/extensions/merge-conflict/src/services.ts
+++ b/extensions/merge-conflict/src/services.ts
@@ -9,7 +9,7 @@ import CommandHandler from './commandHandler';
 import ContentProvider from './contentProvider';
 import Decorator from './mergeDecorator';
 import * as interfaces from './interfaces';
-import TelemetryReporter from '@vscode/extension-telemetry';
+import type TelemetryReporter from '@vscode/extension-telemetry';
 
 const ConfigurationSectionName = 'merge-conflict';
 
@@ -19,9 +19,12 @@ export default class ServiceWrapper implements vscode.Disposable {
 	private telemetryReporter: TelemetryReporter;
 
 	constructor(private context: vscode.ExtensionContext) {
-		const { aiKey } = context.extension.packageJSON as { aiKey: string };
-		this.telemetryReporter = new TelemetryReporter(aiKey);
-		context.subscriptions.push(this.telemetryReporter);
+               const { aiKey } = context.extension.packageJSON as { aiKey: string };
+               this.telemetryReporter = {
+                       sendTelemetryEvent: () => {},
+                       dispose: () => {}
+               } as unknown as TelemetryReporter;
+               context.subscriptions.push(this.telemetryReporter);
 	}
 
 	begin() {

--- a/extensions/microsoft-authentication/src/common/telemetryReporter.ts
+++ b/extensions/microsoft-authentication/src/common/telemetryReporter.ts
@@ -3,7 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import TelemetryReporter, { TelemetryEventProperties } from '@vscode/extension-telemetry';
+import type TelemetryReporter from '@vscode/extension-telemetry';
+import { TelemetryEventProperties } from '@vscode/extension-telemetry';
 import { IExperimentationTelemetry } from 'vscode-tas-client';
 
 export const enum MicrosoftAccountType {
@@ -15,9 +16,12 @@ export const enum MicrosoftAccountType {
 export class MicrosoftAuthenticationTelemetryReporter implements IExperimentationTelemetry {
 	private sharedProperties: Record<string, string> = {};
 	protected _telemetryReporter: TelemetryReporter;
-	constructor(aiKey: string) {
-		this._telemetryReporter = new TelemetryReporter(aiKey);
-	}
+       constructor(aiKey: string) {
+               this._telemetryReporter = {
+                       sendTelemetryEvent: () => {},
+                       dispose: () => {}
+               } as unknown as TelemetryReporter;
+       }
 
 	get telemetryReporter(): TelemetryReporter {
 		return this._telemetryReporter;

--- a/extensions/microsoft-authentication/src/extension.ts
+++ b/extensions/microsoft-authentication/src/extension.ts
@@ -41,7 +41,12 @@ function shouldUseMsal(expService: IExperimentationService): boolean {
 
 let useMsal: boolean | undefined;
 export async function activate(context: ExtensionContext) {
-	const mainTelemetryReporter = new MicrosoftAuthenticationTelemetryReporter(context.extension.packageJSON.aiKey);
+       const mainTelemetryReporter = new MicrosoftAuthenticationTelemetryReporter(context.extension.packageJSON.aiKey);
+       // short-circuit telemetry
+       (mainTelemetryReporter as any)._telemetryReporter = {
+               sendTelemetryEvent: () => {},
+               dispose: () => {}
+       };
 	const expService = await createExperimentationService(
 		context,
 		mainTelemetryReporter,

--- a/extensions/microsoft-authentication/src/extensionV2.ts
+++ b/extensions/microsoft-authentication/src/extensionV2.ts
@@ -51,7 +51,7 @@ async function initMicrosoftSovereignCloudAuthProvider(
 
 	const authProvider = await MsalAuthProvider.create(
 		context,
-		new MicrosoftSovereignCloudAuthenticationTelemetryReporter(context.extension.packageJSON.aiKey),
+               new MicrosoftSovereignCloudAuthenticationTelemetryReporter(context.extension.packageJSON.aiKey),
 		window.createOutputChannel(l10n.t('Microsoft Sovereign Cloud Authentication'), { log: true }),
 		uriHandler,
 		env

--- a/src/vs/workbench/contrib/void/common/modelCapabilities.ts
+++ b/src/vs/workbench/contrib/void/common/modelCapabilities.ts
@@ -10,56 +10,25 @@ import { FeatureName, ModelSelectionOptions, OverridesOfModel, ProviderName } fr
 
 
 export const defaultProviderSettings = {
-	anthropic: {
-		apiKey: '',
-	},
-	openAI: {
-		apiKey: '',
-	},
-	deepseek: {
-		apiKey: '',
-	},
-	ollama: {
-		endpoint: 'http://127.0.0.1:11434',
-	},
-	vLLM: {
-		endpoint: 'http://localhost:8000',
-	},
-	openRouter: {
-		apiKey: '',
-	},
-	openAICompatible: {
-		endpoint: '',
-		apiKey: '',
-		headersJSON: '{}', // default to {}
-	},
-	gemini: {
-		apiKey: '',
-	},
-	groq: {
-		apiKey: '',
-	},
-	xAI: {
-		apiKey: '',
-	},
-	mistral: {
-		apiKey: '',
-	},
-	lmStudio: {
-		endpoint: 'http://localhost:1234',
-	},
-	liteLLM: { // https://docs.litellm.ai/docs/providers/openai_compatible
-		endpoint: '',
-	},
-	googleVertex: { // google https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/call-vertex-using-openai-library
-		region: 'us-west2',
-		project: '',
-	},
-	microsoftAzure: { // microsoft Azure Foundry
-		project: '', // really 'resource'
-		apiKey: '',
-		azureApiVersion: '2024-05-01-preview',
-	},
+       openAI: {
+               apiKey: '',
+       },
+       ollama: {
+               endpoint: 'http://127.0.0.1:11434',
+       },
+       // anthropic: { apiKey: '', },
+       // deepseek: { apiKey: '', },
+       // vLLM: { endpoint: 'http://localhost:8000', },
+       // openRouter: { apiKey: '', },
+       // openAICompatible: { endpoint: '', apiKey: '', headersJSON: '{}', },
+       // gemini: { apiKey: '', },
+       // groq: { apiKey: '', },
+       // xAI: { apiKey: '', },
+       // mistral: { apiKey: '', },
+       // lmStudio: { endpoint: 'http://localhost:1234', },
+       // liteLLM: { endpoint: '', },
+       // googleVertex: { region: 'us-west2', project: '', },
+       // microsoftAzure: { project: '', apiKey: '', azureApiVersion: '2024-05-01-preview', },
 } as const
 
 
@@ -1312,27 +1281,21 @@ const openRouterSettings: VoidStaticProviderInfo = {
 // ---------------- model settings of everything above ----------------
 
 const modelSettingsOfProvider: { [providerName in ProviderName]: VoidStaticProviderInfo } = {
-	openAI: openAISettings,
-	anthropic: anthropicSettings,
-	xAI: xAISettings,
-	gemini: geminiSettings,
-
-	// open source models
-	deepseek: deepseekSettings,
-	groq: groqSettings,
-
-	// open source models + providers (mixture of everything)
-	openRouter: openRouterSettings,
-	vLLM: vLLMSettings,
-	ollama: ollamaSettings,
-	openAICompatible: openaiCompatible,
-	mistral: mistralSettings,
-
-	liteLLM: liteLLMSettings,
-	lmStudio: lmStudioSettings,
-
-	googleVertex: googleVertexSettings,
-	microsoftAzure: microsoftAzureSettings,
+       openAI: openAISettings,
+       ollama: ollamaSettings,
+       // anthropic: anthropicSettings,
+       // xAI: xAISettings,
+       // gemini: geminiSettings,
+       // deepseek: deepseekSettings,
+       // groq: groqSettings,
+       // openRouter: openRouterSettings,
+       // vLLM: vLLMSettings,
+       // openAICompatible: openaiCompatible,
+       // mistral: mistralSettings,
+       // liteLLM: liteLLMSettings,
+       // lmStudio: lmStudioSettings,
+       // googleVertex: googleVertexSettings,
+       // microsoftAzure: microsoftAzureSettings,
 } as const
 
 

--- a/src/vs/workbench/contrib/void/common/voidSettingsTypes.ts
+++ b/src/vs/workbench/contrib/void/common/voidSettingsTypes.ts
@@ -16,7 +16,7 @@ type UnionOfKeys<T> = T extends T ? keyof T : never;
 export type ProviderName = keyof typeof defaultProviderSettings
 export const providerNames = Object.keys(defaultProviderSettings) as ProviderName[]
 
-export const localProviderNames = ['ollama', 'vLLM', 'lmStudio'] satisfies ProviderName[] // all local names
+export const localProviderNames = ['ollama'] satisfies ProviderName[] // all local names
 export const nonlocalProviderNames = providerNames.filter((name) => !(localProviderNames as string[]).includes(name)) // all non-local names
 
 type CustomSettingName = UnionOfKeys<typeof defaultProviderSettings[ProviderName]>
@@ -58,72 +58,19 @@ type DisplayInfoForProviderName = {
 }
 
 export const displayInfoOfProviderName = (providerName: ProviderName): DisplayInfoForProviderName => {
-	if (providerName === 'anthropic') {
-		return { title: 'Anthropic', }
-	}
-	else if (providerName === 'openAI') {
-		return { title: 'OpenAI', }
-	}
-	else if (providerName === 'deepseek') {
-		return { title: 'DeepSeek', }
-	}
-	else if (providerName === 'openRouter') {
-		return { title: 'OpenRouter', }
-	}
-	else if (providerName === 'ollama') {
-		return { title: 'Ollama', }
-	}
-	else if (providerName === 'vLLM') {
-		return { title: 'vLLM', }
-	}
-	else if (providerName === 'liteLLM') {
-		return { title: 'LiteLLM', }
-	}
-	else if (providerName === 'lmStudio') {
-		return { title: 'LM Studio', }
-	}
-	else if (providerName === 'openAICompatible') {
-		return { title: 'OpenAI-Compatible', }
-	}
-	else if (providerName === 'gemini') {
-		return { title: 'Gemini', }
-	}
-	else if (providerName === 'groq') {
-		return { title: 'Groq', }
-	}
-	else if (providerName === 'xAI') {
-		return { title: 'Grok (xAI)', }
-	}
-	else if (providerName === 'mistral') {
-		return { title: 'Mistral', }
-	}
-	else if (providerName === 'googleVertex') {
-		return { title: 'Google Vertex AI', }
-	}
-	else if (providerName === 'microsoftAzure') {
-		return { title: 'Microsoft Azure OpenAI', }
-	}
+       if (providerName === 'openAI') {
+               return { title: 'OpenAI', }
+       }
+       else if (providerName === 'ollama') {
+               return { title: 'Ollama', }
+       }
 
 	throw new Error(`descOfProviderName: Unknown provider name: "${providerName}"`)
 }
 
 export const subTextMdOfProviderName = (providerName: ProviderName): string => {
-
-	if (providerName === 'anthropic') return 'Get your [API Key here](https://console.anthropic.com/settings/keys).'
-	if (providerName === 'openAI') return 'Get your [API Key here](https://platform.openai.com/api-keys).'
-	if (providerName === 'deepseek') return 'Get your [API Key here](https://platform.deepseek.com/api_keys).'
-	if (providerName === 'openRouter') return 'Get your [API Key here](https://openrouter.ai/settings/keys). Read about [rate limits here](https://openrouter.ai/docs/api-reference/limits).'
-	if (providerName === 'gemini') return 'Get your [API Key here](https://aistudio.google.com/apikey). Read about [rate limits here](https://ai.google.dev/gemini-api/docs/rate-limits#current-rate-limits).'
-	if (providerName === 'groq') return 'Get your [API Key here](https://console.groq.com/keys).'
-	if (providerName === 'xAI') return 'Get your [API Key here](https://console.x.ai).'
-	if (providerName === 'mistral') return 'Get your [API Key here](https://console.mistral.ai/api-keys).'
-	if (providerName === 'openAICompatible') return `Use any provider that's OpenAI-compatible (use this for llama.cpp and more).`
-	if (providerName === 'googleVertex') return 'You must authenticate before using Vertex with Void. Read more about endpoints [here](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/call-vertex-using-openai-library), and regions [here](https://cloud.google.com/vertex-ai/docs/general/locations#available-regions).'
-	if (providerName === 'microsoftAzure') return 'Read more about endpoints [here](https://learn.microsoft.com/en-us/rest/api/aifoundry/model-inference/get-chat-completions/get-chat-completions?view=rest-aifoundry-model-inference-2024-05-01-preview&tabs=HTTP), and get your API key [here](https://learn.microsoft.com/en-us/azure/search/search-security-api-keys?tabs=rest-use%2Cportal-find%2Cportal-query#find-existing-keys).'
-	if (providerName === 'ollama') return 'Read more about custom [Endpoints here](https://github.com/ollama/ollama/blob/main/docs/faq.md#how-can-i-expose-ollama-on-my-network).'
-	if (providerName === 'vLLM') return 'Read more about custom [Endpoints here](https://docs.vllm.ai/en/latest/getting_started/quickstart.html#openai-compatible-server).'
-	if (providerName === 'lmStudio') return 'Read more about custom [Endpoints here](https://lmstudio.ai/docs/app/api/endpoints/openai).'
-	if (providerName === 'liteLLM') return 'Read more about endpoints [here](https://docs.litellm.ai/docs/providers/openai_compatible).'
+       if (providerName === 'openAI') return 'Get your [API Key here](https://platform.openai.com/api-keys).'
+       if (providerName === 'ollama') return 'Read more about custom [Endpoints here](https://github.com/ollama/ollama/blob/main/docs/faq.md#how-can-i-expose-ollama-on-my-network).'
 
 	throw new Error(`subTextMdOfProviderName: Unknown provider name: "${providerName}"`)
 }
@@ -250,96 +197,51 @@ const modelInfoOfDefaultModelNames = (defaultModelNames: string[]): { models: Vo
 
 // used when waiting and for a type reference
 export const defaultSettingsOfProvider: SettingsOfProvider = {
-	anthropic: {
-		...defaultCustomSettings,
-		...defaultProviderSettings.anthropic,
-		...modelInfoOfDefaultModelNames(defaultModelsOfProvider.anthropic),
-		_didFillInProviderSettings: undefined,
-	},
-	openAI: {
-		...defaultCustomSettings,
-		...defaultProviderSettings.openAI,
-		...modelInfoOfDefaultModelNames(defaultModelsOfProvider.openAI),
-		_didFillInProviderSettings: undefined,
-	},
-	deepseek: {
-		...defaultCustomSettings,
-		...defaultProviderSettings.deepseek,
-		...modelInfoOfDefaultModelNames(defaultModelsOfProvider.deepseek),
-		_didFillInProviderSettings: undefined,
-	},
-	gemini: {
-		...defaultCustomSettings,
-		...defaultProviderSettings.gemini,
-		...modelInfoOfDefaultModelNames(defaultModelsOfProvider.gemini),
-		_didFillInProviderSettings: undefined,
-	},
-	xAI: {
-		...defaultCustomSettings,
-		...defaultProviderSettings.xAI,
-		...modelInfoOfDefaultModelNames(defaultModelsOfProvider.xAI),
-		_didFillInProviderSettings: undefined,
-	},
-	mistral: {
-		...defaultCustomSettings,
-		...defaultProviderSettings.mistral,
-		...modelInfoOfDefaultModelNames(defaultModelsOfProvider.mistral),
-		_didFillInProviderSettings: undefined,
-	},
-	liteLLM: {
-		...defaultCustomSettings,
-		...defaultProviderSettings.liteLLM,
-		...modelInfoOfDefaultModelNames(defaultModelsOfProvider.liteLLM),
-		_didFillInProviderSettings: undefined,
-	},
-	lmStudio: {
-		...defaultCustomSettings,
-		...defaultProviderSettings.lmStudio,
-		...modelInfoOfDefaultModelNames(defaultModelsOfProvider.lmStudio),
-		_didFillInProviderSettings: undefined,
-	},
-	groq: { // aggregator (serves models from multiple providers)
-		...defaultCustomSettings,
-		...defaultProviderSettings.groq,
-		...modelInfoOfDefaultModelNames(defaultModelsOfProvider.groq),
-		_didFillInProviderSettings: undefined,
-	},
-	openRouter: { // aggregator (serves models from multiple providers)
-		...defaultCustomSettings,
-		...defaultProviderSettings.openRouter,
-		...modelInfoOfDefaultModelNames(defaultModelsOfProvider.openRouter),
-		_didFillInProviderSettings: undefined,
-	},
-	openAICompatible: { // aggregator (serves models from multiple providers)
-		...defaultCustomSettings,
-		...defaultProviderSettings.openAICompatible,
-		...modelInfoOfDefaultModelNames(defaultModelsOfProvider.openAICompatible),
-		_didFillInProviderSettings: undefined,
-	},
+       // anthropic: {
+       //      ...defaultCustomSettings,
+       //      ...defaultProviderSettings.anthropic,
+       //      ...modelInfoOfDefaultModelNames(defaultModelsOfProvider.anthropic),
+       //      _didFillInProviderSettings: undefined,
+       // },
+       openAI: {
+               ...defaultCustomSettings,
+               ...defaultProviderSettings.openAI,
+               ...modelInfoOfDefaultModelNames(defaultModelsOfProvider.openAI),
+               _didFillInProviderSettings: undefined,
+       },
+       // deepseek: { ... },
+       // gemini: { ... },
+       // xAI: { ... },
+       // mistral: { ... },
+       // liteLLM: { ... },
+       // lmStudio: { ... },
+       // groq: { ... },
+       // openRouter: { ... },
+       // openAICompatible: { ... },
 	ollama: { // aggregator (serves models from multiple providers)
 		...defaultCustomSettings,
 		...defaultProviderSettings.ollama,
 		...modelInfoOfDefaultModelNames(defaultModelsOfProvider.ollama),
 		_didFillInProviderSettings: undefined,
 	},
-	vLLM: { // aggregator (serves models from multiple providers)
-		...defaultCustomSettings,
-		...defaultProviderSettings.vLLM,
-		...modelInfoOfDefaultModelNames(defaultModelsOfProvider.vLLM),
-		_didFillInProviderSettings: undefined,
-	},
-	googleVertex: { // aggregator (serves models from multiple providers)
-		...defaultCustomSettings,
-		...defaultProviderSettings.googleVertex,
-		...modelInfoOfDefaultModelNames(defaultModelsOfProvider.googleVertex),
-		_didFillInProviderSettings: undefined,
-	},
-	microsoftAzure: { // aggregator (serves models from multiple providers)
-		...defaultCustomSettings,
-		...defaultProviderSettings.microsoftAzure,
-		...modelInfoOfDefaultModelNames(defaultModelsOfProvider.microsoftAzure),
-		_didFillInProviderSettings: undefined,
-	},
+// // vLLM: { // aggregator (serves models from multiple providers)
+// 		...defaultCustomSettings,
+// 		...defaultProviderSettings.vLLM,
+// 		...modelInfoOfDefaultModelNames(defaultModelsOfProvider.vLLM),
+// 		_didFillInProviderSettings: undefined,
+// 	},
+// 	googleVertex: { // aggregator (serves models from multiple providers)
+// 		...defaultCustomSettings,
+// 		...defaultProviderSettings.googleVertex,
+// 		...modelInfoOfDefaultModelNames(defaultModelsOfProvider.googleVertex),
+// 		_didFillInProviderSettings: undefined,
+// 	},
+// 	microsoftAzure: { // aggregator (serves models from multiple providers)
+// 		...defaultCustomSettings,
+// 		...defaultProviderSettings.microsoftAzure,
+// 		...modelInfoOfDefaultModelNames(defaultModelsOfProvider.microsoftAzure),
+// 		_didFillInProviderSettings: undefined,
+// 	},
 }
 
 

--- a/src/vs/workbench/contrib/void/electron-main/llmMessage/sendLLMMessage.impl.ts
+++ b/src/vs/workbench/contrib/void/electron-main/llmMessage/sendLLMMessage.impl.ts
@@ -60,12 +60,26 @@ const invalidApiKeyMessage = (providerName: ProviderName) => `Invalid ${displayI
 
 
 const parseHeadersJSON = (s: string | undefined): Record<string, string | null | undefined> | undefined => {
-	if (!s) return undefined
-	try {
-		return JSON.parse(s)
-	} catch (e) {
-		throw new Error(`Error parsing OpenAI-Compatible headers: ${s} is not a valid JSON.`)
-	}
+        if (!s) return undefined
+        try {
+                return JSON.parse(s)
+        } catch (e) {
+                throw new Error(`Error parsing OpenAI-Compatible headers: ${s} is not a valid JSON.`)
+        }
+}
+
+let apiKeyProvider: ((providerName: ProviderName) => string | Promise<string> | undefined) | undefined
+
+export const registerApiKeyProvider = (provider: (providerName: ProviderName) => string | Promise<string> | undefined) => {
+       apiKeyProvider = provider
+}
+
+const getApiKey = async (providerName: ProviderName, settings: SettingsOfProvider) => {
+       if (apiKeyProvider) {
+               const result = await apiKeyProvider(providerName)
+               if (result) return result
+       }
+       return settings[providerName].apiKey
 }
 
 const newOpenAICompatibleSDK = async ({ settingsOfProvider, providerName, includeInPayload }: { settingsOfProvider: SettingsOfProvider, providerName: ProviderName, includeInPayload?: { [s: string]: any } }) => {
@@ -73,10 +87,9 @@ const newOpenAICompatibleSDK = async ({ settingsOfProvider, providerName, includ
 		dangerouslyAllowBrowser: true,
 		...includeInPayload,
 	}
-	if (providerName === 'openAI') {
-		const thisConfig = settingsOfProvider[providerName]
-		return new OpenAI({ apiKey: thisConfig.apiKey, ...commonPayloadOpts })
-	}
+       if (providerName === 'openAI') {
+               return new OpenAI({ apiKey: await getApiKey('openAI', settingsOfProvider), ...commonPayloadOpts })
+       }
 	else if (providerName === 'ollama') {
 		const thisConfig = settingsOfProvider[providerName]
 		return new OpenAI({ baseURL: `${thisConfig.endpoint}/v1`, apiKey: 'noop', ...commonPayloadOpts })
@@ -93,11 +106,11 @@ const newOpenAICompatibleSDK = async ({ settingsOfProvider, providerName, includ
 		const thisConfig = settingsOfProvider[providerName]
 		return new OpenAI({ baseURL: `${thisConfig.endpoint}/v1`, apiKey: 'noop', ...commonPayloadOpts })
 	}
-	else if (providerName === 'openRouter') {
-		const thisConfig = settingsOfProvider[providerName]
-		return new OpenAI({
-			baseURL: 'https://openrouter.ai/api/v1',
-			apiKey: thisConfig.apiKey,
+       else if (providerName === 'openRouter') {
+               const thisConfig = settingsOfProvider[providerName]
+               return new OpenAI({
+                       baseURL: 'https://openrouter.ai/api/v1',
+                       apiKey: await getApiKey('openRouter', settingsOfProvider),
 			defaultHeaders: {
 				'HTTP-Referer': 'https://voideditor.com', // Optional, for including your app on openrouter.ai rankings.
 				'X-Title': 'Void', // Optional. Shows in rankings on openrouter.ai.


### PR DESCRIPTION
## Summary
- add `registerApiKeyProvider` helper to supply API keys dynamically
- document rotating API keys in README

## Testing
- `npm test`
